### PR TITLE
Resetting useDbConfig attribute in runtime config that was erroneously p...

### DIFF
--- a/Model/Behavior/AutocacheBehavior.php
+++ b/Model/Behavior/AutocacheBehavior.php
@@ -154,6 +154,7 @@ class AutocacheBehavior extends ModelBehavior {
 
 			// reset the useDbConfig attribute back to what it was
 			$model->useDbConfig = $this->runtime[$model->alias]['useDbConfig'];
+			unset($this->runtime[$model->alias]['useDbConfig']);
 
 			// A flag to indicate in the Model if the last query was from cache
 			if ($this->__cached_results) {


### PR DESCRIPTION
...ersistent between multiple finds performed against a given model.

In afterFind, the runtime config's useDbConfig attribute is the flag that indicates there are cached results to be returned. However, that attribute was never being reset even though the runtime config is persistent through the lifetime of the behavior, which may involve multiple calls to a model's find methods. If multiple find requests were performed in the same model in the same HTTP request, the useDbConfig attribute could get stuck and would prevent the results all but the first of any given model's find from being cached.
